### PR TITLE
chore: add export compliance declaration

### DIFF
--- a/GeneralElection2017/Info.plist
+++ b/GeneralElection2017/Info.plist
@@ -44,5 +44,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Added export compliance declaration to `Info.plist` file.
This app does not use non-exempt encryption.