### PR TITLE
fix: fixed sorting of parties when no policies have been swiped

### DIFF
--- a/GeneralElection2017/PartiesView.swift
+++ b/GeneralElection2017/PartiesView.swift
@@ -30,7 +30,7 @@ struct PartyMapping {
     var ratio: Double {
         let likedCount = Double(agreement.count)
         let dislikedCount = Double(disagreement.count)
-        return likedCount / (likedCount + dislikedCount)
+        return likedCount / max(likedCount + dislikedCount, .leastNonzeroMagnitude)
     }
 }
 


### PR DESCRIPTION
Ensured that policies are sorted in order, even when other parties are scored at 0.

|Before|After|
|-|-|
|![image](https://github.com/Oliver-Binns/Choose/assets/5354593/23ebf0e6-cb7a-4ef0-a1bf-abf593c0214b)|![image](https://github.com/Oliver-Binns/Choose/assets/5354593/52271d57-0d8e-48f4-a8de-7b330abbbb07)|