### PR TITLE
feat: display additional info on policy card

### DIFF
--- a/GeneralElection2017/PolicyView.swift
+++ b/GeneralElection2017/PolicyView.swift
@@ -13,7 +13,7 @@ struct PolicyView: View {
     var opacity: Double {
         3 - Double(abs(offset.distance / 100))
     }
-    
+
     @State private var isShowingAdditionalInfo = false
 
     @MainActor
@@ -51,19 +51,23 @@ struct PolicyView: View {
         }
     }
 
+    var additionalInfoLabel: String {
+        isShowingAdditionalInfo ? "Hide" : "Show" + "Additional Info"
+    }
+
+    var additionalInfoImage: String {
+        isShowingAdditionalInfo ? "arrow.uturn.left.circle.fill" : "info.circle.fill"
+    }
+
     var body: some View {
         ZStack {
             FlippableCard(isFlipped: $isShowingAdditionalInfo) {
-                
                 Text(policy.text)
                     .multilineTextAlignment(.center)
                     .padding()
                     .font(.largeTitle)
                     .fontWeight(.bold)
                     .foregroundColor(.white)
-                
-                
-                
             } back: {
                 if let info = policy.additionalInfo {
                     Text(info)
@@ -75,18 +79,18 @@ struct PolicyView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.black.opacity(0.5))
-            
+
             if policy.additionalInfo != nil {
                 VStack(alignment: .trailing) {
                     Spacer()
                     HStack {
                         Spacer()
-                        
+
                         Button {
                             isShowingAdditionalInfo.toggle()
                         } label: {
-                            Label(isShowingAdditionalInfo ? "Hide" : "Show" + "Additional Info",
-                                  systemImage: isShowingAdditionalInfo ? "arrow.uturn.left.circle.fill" : "info.circle.fill")
+                            Label(additionalInfoLabel,
+                                  systemImage: additionalInfoImage)
                             .labelStyle(.iconOnly)
                         }
                     }
@@ -95,7 +99,7 @@ struct PolicyView: View {
                 .buttonStyle(.plain)
                 .foregroundColor(.white)
             }
-            
+
             Rectangle()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .foregroundColor(opinionColour)

--- a/GeneralElection2017/PolicyView.swift
+++ b/GeneralElection2017/PolicyView.swift
@@ -13,6 +13,8 @@ struct PolicyView: View {
     var opacity: Double {
         3 - Double(abs(offset.distance / 100))
     }
+    
+    @State private var isShowingAdditionalInfo = false
 
     @MainActor
     var drag: some Gesture {
@@ -51,15 +53,49 @@ struct PolicyView: View {
 
     var body: some View {
         ZStack {
-            Text(policy.text)
-                .multilineTextAlignment(.center)
+            FlippableCard(isFlipped: $isShowingAdditionalInfo) {
+                
+                Text(policy.text)
+                    .multilineTextAlignment(.center)
+                    .padding()
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+                
+                
+                
+            } back: {
+                if let info = policy.additionalInfo {
+                    Text(info)
+                        .multilineTextAlignment(.center)
+                        .font(.headline)
+                        .padding(32)
+                        .foregroundColor(.white)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.black.opacity(0.5))
+            
+            if policy.additionalInfo != nil {
+                VStack(alignment: .trailing) {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        
+                        Button {
+                            isShowingAdditionalInfo.toggle()
+                        } label: {
+                            Label("Show Additional Info",
+                                  systemImage: "info.circle.fill")
+                            .labelStyle(.iconOnly)
+                        }
+                    }
+                }
                 .padding()
-                .font(.largeTitle)
-                .fontWeight(.bold)
+                .buttonStyle(.plain)
                 .foregroundColor(.white)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(.black.opacity(0.5))
-
+            }
+            
             Rectangle()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .foregroundColor(opinionColour)

--- a/GeneralElection2017/PolicyView.swift
+++ b/GeneralElection2017/PolicyView.swift
@@ -85,8 +85,8 @@ struct PolicyView: View {
                         Button {
                             isShowingAdditionalInfo.toggle()
                         } label: {
-                            Label("Show Additional Info",
-                                  systemImage: "info.circle.fill")
+                            Label(isShowingAdditionalInfo ? "Hide" : "Show" + "Additional Info",
+                                  systemImage: isShowingAdditionalInfo ? "arrow.uturn.left.circle.fill" : "info.circle.fill")
                             .labelStyle(.iconOnly)
                         }
                     }


### PR DESCRIPTION
Users can now flip policy cards over to find out more details about a particular policy.

|![image](https://github.com/Oliver-Binns/Choose/assets/5354593/40e862f2-1b22-4567-9ade-a2aeaffe052e)|![image](https://github.com/Oliver-Binns/Choose/assets/5354593/cf0d2c79-8a78-43f8-8d6c-377bad1b653f)|
|-|-|