### PR TITLE
fix: only clear policies if update contains data

### DIFF
--- a/GeneralElection/Sources/Policies/PolicyService.swift
+++ b/GeneralElection/Sources/Policies/PolicyService.swift
@@ -31,14 +31,14 @@ final actor PolicyService: ModelActor {
         let decoder = JSONDecoder()
         let policies = try decoder.decode([PolicyLite].self, from: data)
             .map(Policy.init)
-        
+
         guard !policies.isEmpty else {
             // only update stored policies if we have new ones to replace with
             return
         }
-        
+
         try modelContext.delete(model: Policy.self)
-        
+
         policies.forEach {
             modelContext.insert($0)
         }

--- a/GeneralElection/Sources/Policies/PolicyService.swift
+++ b/GeneralElection/Sources/Policies/PolicyService.swift
@@ -28,14 +28,20 @@ final actor PolicyService: ModelActor {
     }
 
     private func loadModels(from data: Data) throws {
-        try modelContext.delete(model: Policy.self)
-
         let decoder = JSONDecoder()
-        try decoder.decode([PolicyLite].self, from: data)
+        let policies = try decoder.decode([PolicyLite].self, from: data)
             .map(Policy.init)
-            .forEach {
-                modelContext.insert($0)
-            }
+        
+        guard !policies.isEmpty else {
+            // only update stored policies if we have new ones to replace with
+            return
+        }
+        
+        try modelContext.delete(model: Policy.self)
+        
+        policies.forEach {
+            modelContext.insert($0)
+        }
 
         try modelContext.save()
     }

--- a/GeneralElection/Tests/PoliciesTests/PolicyServiceTests.swift
+++ b/GeneralElection/Tests/PoliciesTests/PolicyServiceTests.swift
@@ -54,4 +54,23 @@ extension PolicyServiceTests {
         XCTAssertEqual(policy.parties, [.liberalDemocrats, .snp])
         XCTAssertEqual(policy.type, .foreignAffairs)
     }
+
+    func testAddPoliciesWithEmptyData() async throws {
+        let data = try JSONEncoder()
+            .encode([PolicyLite]())
+
+        MockURLProtocol.requestHandler = { _ in
+            (.success, data)
+        }
+
+        try await sut.loadAllPolicies()
+
+        let descriptor = FetchDescriptor<Policy>(sortBy: [
+            SortDescriptor(\.id, order: .forward)
+        ])
+        let policies = try modelContext
+            .fetch(descriptor)
+
+        XCTAssertEqual(policies.count, 10)
+    }
 }


### PR DESCRIPTION
Previously the Policy data was deleted when the network call returned without decoding the data.
This meant that if corrupted data was returned, the app would end up with no policies being shown.

This change updates that, so that at least one new policy must be added for the data to be cleared.