### PR TITLE
ci: automatically deploy to external testers

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -76,7 +76,10 @@ platform :ios do
 
       upload_to_testflight(
         skip_submission: true,
-        app_platform: "ios"
+        app_platform: "ios",
+        distribute_external: true,
+        groups: "Core Group",
+        changelog: last_git_commit[:message]
       )
     ensure
       delete_keychain(name: keychain_name)


### PR DESCRIPTION
Automatically deploys to the external testers in the "Core Group" when a change is merged.